### PR TITLE
In send_lambda, account for the possiblity of different parent range types

### DIFF
--- a/src/sfuncs/compound/mixture.jl
+++ b/src/sfuncs/compound/mixture.jl
@@ -182,7 +182,8 @@ end
                        parent_ix::Integer)::Score where {N,I,O}
 
         # Need to make sure the target parent range is a Vector{T} rather than a Vector{Any}
-        T = typeof(parranges[parent_ix][1])
+        T = typejoin([typeof(x) for x in parranges[parent_ix]]...)
+        
         target_parrange :: Vector{T} = parranges[parent_ix]
         lams = [send_lambda(comp, lambda, range, parranges, incoming_pis, parent_ix) for comp in sf.components]
         scores = [[get_score(lams[j], target_parrange[i]) for i in 1:length(target_parrange)] for j in 1:length(sf.components)]

--- a/src/sfuncs/conddist/conditional.jl
+++ b/src/sfuncs/conddist/conditional.jl
@@ -287,7 +287,7 @@ end
         jinds = cartesian_product(jar)
         result = zeros(Float64, length(parranges[parent_ix]))
         # Need to make sure the target parent range is a Vector{T} rather than a Vector{Any}
-        T = typeof(parranges[parent_ix][1])
+        T = typejoin([typeof(x) for x in parranges[parent_ix]]...)
         target_parrange :: Vector{T} = parranges[parent_ix]
 
         if parent_ix <= length(iranges)

--- a/src/sfuncs/conddist/det.jl
+++ b/src/sfuncs/conddist/det.jl
@@ -192,7 +192,7 @@ end
         # For a particular parent, we consider all possible values of the other parents.
         # We make a joint argument p, and compute pi(other parents) * lambda(f(p)).
         # Need to make sure the target parent range is a Vector{T} rather than a Vector{Any}
-        T = typeof(parranges[parent_ix][1])
+        T = typejoin([typeof(x) for x in parranges[parent_ix]]...)
         target_parrange :: Vector{T} = parranges[parent_ix]
         otherranges = [r for r in parranges]
         deleteat!(otherranges, parent_ix)

--- a/src/sfuncs/conddist/switch.jl
+++ b/src/sfuncs/conddist/switch.jl
@@ -168,7 +168,7 @@ end
 
         # We need to make sure the message is correctly typed to the output type of the appropriate parent
         # Need to make sure the target parent range is a Vector{T} rather than a Vector{Any}
-        T = typeof(parranges[parent_ix][1])
+        T = typejoin([typeof(x) for x in parranges[parent_ix]]...)
         target_parrange :: Vector{T} = parranges[parent_ix]
         if parent_ix == 1
             # We send a lambda message to the selector parent


### PR DESCRIPTION
The casting of parent ranges in send_lambda did not account for the possibility that the types in the parents might be disparate; new we consider this possibility