### PR TITLE
Fast implementation of greedy ordering heuristic.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.9.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+CliqueTrees = "60701a23-6482-424a-84db-faee86b9b1f8"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -23,6 +24,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 AbstractTrees = "0.3.4 - 0.4"
+CliqueTrees = "0.5.1"
 DataStructures = "0.18"
 Distributions = "0.25"
 Folds = "0.2.7"

--- a/src/algorithms/instant/ve.jl
+++ b/src/algorithms/instant/ve.jl
@@ -2,6 +2,7 @@ export
     VE,
     ve
 
+import CliqueTrees
 import ..Operators.make_factors
 import ..SFuncs: Invertible, Serial
 using Folds
@@ -413,6 +414,45 @@ function greedy_order(g :: Graph, to_leave :: Array{Int})
         deleteat!(candidates, findfirst(n -> n == best, candidates))
     end
     return result
+end
+
+function speedy_greedy_order(g :: Graph, to_leave :: Array{Int})
+    n = length(g.nodes)
+    m = length(to_leave)
+    index = sizehint!(Dict{Int, Int}(), n)
+    graph = CliqueTrees.Graph{Int}(n)
+    clique = Vector{Int}(undef, m)
+
+    # construct index
+    for (i, v) in enumerate(g.nodes)
+        index[v] = i
+    end
+    
+    # construct graph
+    for v in g.nodes
+        for w in g.edges[v]
+            if index[v] < index[w]
+                CliqueTrees.add_edge!(graph, index[v], index[w])
+            end
+        end
+    end
+    
+    # form a clique from the variables in `to_leave`
+    for i in 1:m
+        v = to_leave[i]
+        
+        for ii in i + 1:m
+            vv = to_leave[ii]
+            CliqueTrees.add_edge!(graph, index[v], index[vv])
+        end
+        
+        clique[i] = index[v]
+    end
+    
+    # compute ordering
+    alg = CliqueTrees.CompositeRotations(clique, CliqueTrees.MF())
+    perm, _ = CliqueTrees.permutation(graph; alg)
+    return g.nodes[perm[begin:end - m]]
 end
 
 function greedy_order(g :: Graph)

--- a/src/algorithms/instant/ve.jl
+++ b/src/algorithms/instant/ve.jl
@@ -403,20 +403,6 @@ function cost(g :: Graph, n :: Int)
 end
 
 function greedy_order(g :: Graph, to_leave :: Array{Int})
-    candidates = filter(n -> !(n in to_leave), g.nodes)
-    result = []
-    h = copy_graph(g)
-    while !isempty(candidates)
-        costs = map(c -> cost(h, c), candidates)
-        best = candidates[argmin(costs)]
-        push!(result, best)
-        eliminate(h, best)
-        deleteat!(candidates, findfirst(n -> n == best, candidates))
-    end
-    return result
-end
-
-function speedy_greedy_order(g :: Graph, to_leave :: Array{Int})
     n = length(g.nodes)
     m = length(to_leave)
     index = sizehint!(Dict{Int, Int}(), n)


### PR DESCRIPTION
The `greedy_order` function is prohibitively slow for large graphs. This patch adds a faster implementation of the same algorithm. Here are some benchmarks.

```julia
using Scruff.Algorithms: Graph, greedy_order, speedy_greedy_order, copy_graph, add_node!, add_undirected!
using MatrixMarket, SuiteSparseMatrixCollection, SparseArrays

ssmc = ssmc_db(); name = "bcsstk08"
matrix = mmread(joinpath(fetch_ssmc(ssmc[ssmc.name .== name, :], format="MM")[1], "$(name).mtx"))
graph = Graph()

for j in axes(matrix, 2)
    add_node!(graph, j, 1)
end
    
for j in axes(matrix, 2)
    for i in @view rowvals(matrix)[nzrange(matrix, j)]
        if i < j
            add_undirected!(graph, i, j)
            
        end
    end
end

to_leave = [1, 1000, 500]
```

**current implementation**

```julia
julia> @time greedy_order(graph, to_leave);
 25.647365 seconds (281.58 M allocations: 13.979 GiB, 2.97% gc time)
```

**new implementation**

```julia
julia> @time speedy_greedy_order(graph, to_leave);
  0.008457 seconds (7.30 k allocations: 2.074 MiB)
```