### PR TITLE
fixing range limited BP for categorical distributions

### DIFF
--- a/src/algorithms/filtering/rangelimited.jl
+++ b/src/algorithms/filtering/rangelimited.jl
@@ -41,8 +41,11 @@ function set_range_and_belief_limited!(runtime, instance, name, ranges, limit)
     if has_belief(runtime, instance)
         belief = get_belief(runtime, instance)
         samples = limited_support(belief, (), limit)
-        ranges[name] = samples 
-        new_belief = Cat(samples, [1.0 / length(samples) for s in samples])
+        ranges[name] = samples
+        probs = [cpdf(belief, (), s) for s in samples]
+        total = sum(probs)
+        weights = total > 0 ? probs ./ total : fill(1.0 / length(samples), length(samples))
+        new_belief = Cat(samples, weights)
         post_belief!(runtime, instance, new_belief)
     end
 end

--- a/src/sfuncs/conddist/conditional.jl
+++ b/src/sfuncs/conddist/conditional.jl
@@ -105,10 +105,14 @@ end
         # create range by mixing values from ranges created by each combination of parents values up to size
         allrng = collect(Iterators.flatten(values(allcombranges)))
         max_size = length(unique(allrng))
+        parity = true
         while length(rng) < min(size, max_size)
             for is in isrange
+                parity = !parity
                 if(length(allcombranges[is]) > 0)
-                    val = popfirst!(allcombranges[is])
+                    mid_idx = div(length(allcombranges[is]) + 1 + parity, 2)
+                    val = allcombranges[is][mid_idx]
+                    deleteat!(allcombranges[is], mid_idx)
                     push!(rng, val)
                 end
             end

--- a/test/test_filter.jl
+++ b/test/test_filter.jl
@@ -1409,6 +1409,94 @@ import Scruff: make_initial, make_transition
             @test length(support(bel2, (), 1000, Int[])) <= 2
         end
 
+        @testset "Handle Categorical Distributions properly" begin 
+            function discrete_uniform(range::Array)
+                len = length(range)
+                Cat(range, fill(1/len, len))
+            end
+            
+            possible_values = ["a", "b", "c"]
+            struct M1 <: VariableTimeModel{Tuple{}, Tuple{String}, String} end 
+            make_initial(::M1, t) = discrete_uniform(possible_values)
+            make_transition(::M1, parts, t) =
+                Chain(Tuple{String}, String, tuple -> begin 
+                    parent = tuple[1]
+                    new_val = discrete_uniform(possible_values)
+                    Mixture([Constant(parent), new_val], [0.5, 0.5])
+                end)
+
+            mutable struct RuntimeContainer
+                const alg::Algorithm
+                const runtime::Runtime
+                const network::Network
+                var_dict::Dict{Symbol, Variable}
+                time::Int64
+            end
+
+            function initialize_network(
+                var_dict, graph, parent_time_offset=VariableParentTimeOffset(), 
+                num_samples::Int64=100, range_limited_vars=Symbol[])
+                variables = collect(values(var_dict))
+                net = DynamicNetwork(variables, VariableGraph(), VariableGraph(graph), parent_time_offset)
+                runtime = Runtime(net)
+                # decide on algorithm - either AsyncPF or range limited BP
+                # alg = AsyncPF(num_samples, num_samples, Int) 
+                alg = create_range_limited_bp(num_samples, range_limited_vars)
+                init_filter(alg, runtime)
+                return RuntimeContainer(alg, runtime, net, var_dict, 1)
+            end
+
+            function create_range_limited_bp(range_size, range_limited_vars)
+                range_sizes = Dict{Symbol, Int64}()
+                for var in range_limited_vars
+                    range_sizes[var] = range_size
+                end
+                RangeLimited(
+                    AsyncBP(range_size, Int),
+                    range_sizes,
+                )
+            end
+
+            function run_inference(container::RuntimeContainer, evidence::Dict{Symbol, Score}, queries::Vector)
+                alg = container.alg
+                runtime = container.runtime
+                t = container.time
+                if !isa(alg, RangeLimited) && isa(alg.inference_algorithm, Importance)
+                    particles = get_state(runtime, :particles)
+                    newParticles = resample(particles)
+                    set_state!(runtime, :particles, newParticles)
+                end
+                variables = collect(values(container.var_dict))
+                filter_step(alg, runtime, variables, t, evidence)
+                results_dict = Dict{Symbol, Dict}()
+                for var_name in queries 
+                    state_var = container.var_dict[var_name]
+                    belief_state = marginal(alg, runtime, current_instance(runtime, state_var))
+                    inverse_map = belief_state.__inversemap # need to use inverse map to map to probs
+                    state_probs = Dict()
+                    for (state, i) in inverse_map
+                        state_probs[state] = belief_state.params[i]
+                    end
+                    results_dict[var_name] = state_probs  
+                end
+                container.time += 1
+                return results_dict
+            end
+            m1 = M1()(:model1)
+            var_dict = Dict{Symbol, Variable}(
+                :model1 => m1,
+            )
+            graph = VariableGraph(m1 => [m1])
+            num_samples = 200
+            container = initialize_network(var_dict, graph, VariableParentTimeOffset(), num_samples, [:model1]) 
+            result = run_inference(container, Dict{Symbol, Score}(), [:model1])
+            for e in possible_values
+                @test result[:model1][e] == 1/3
+            end
+            result = run_inference(container, Dict{Symbol, Score}(:model1 => HardScore("a")), [:model1])
+            @test result[:model1] == Dict("c" => 0.0, "b" => 0.0, "a" => 1.0)
+        end
+
     #=
     @testset "Profiling filtering algorithms" begin
             norm = Normal(0.0, 1.0)


### PR DESCRIPTION
Fixes a bug where posterior belief weights weren't properly being stored for `RangeLimitedBP`

For Categorical distributions, this meant that evidence would essentially get ignored 

Notably, for continuous distributions, this was ok, because RangeLimitedBP would fall back to using sampling for distributions with infinite support

Also fixed a bug in `ConditionalSupport`  that created a bias where generated values in BP would converge to the smallest value in each range 